### PR TITLE
Callback instead of StopVideo

### DIFF
--- a/js/tabby.js
+++ b/js/tabby.js
@@ -36,21 +36,6 @@ window.tabby = (function (window, document, undefined) {
 		return original;
 	};
 
-	// Stop YouTube, Vimeo, and HTML5 videos from playing when leaving the tab
-	// Private method
-	// Runs functions
-	var _stopVideo = function (tab) {
-		var iframe = tab.querySelector( 'iframe');
-		var video = tab.querySelector( 'video' );
-		if ( iframe !== null ) {
-			var iframeSrc = iframe.src;
-			iframe.src = iframeSrc;
-		}
-		if ( video !== null ) {
-			video.pause();
-		}
-	};
-
 	// Remove '.active' class from all other tab toggles
 	// Private method
 	// Runs functions
@@ -71,7 +56,6 @@ window.tabby = (function (window, document, undefined) {
 			//only change if the tab was active
 			if (buoy.hasClass(tab,options.contentActiveClass)){
 				buoy.removeClass(tab, options.contentActiveClass);
-				_stopVideo(tab);
 				//call after hiding tab
 				options.callbackHide(tab);
 			}


### PR DESCRIPTION
UPDATE: As I am new to GitHub I needed to clean up this request.

I think the videoStop function should not be included, to give us more control. Single Responsibility.

By moving it to a callback function I can now decide how to handle it. The ~~four~~ 2 new callback functions are called ~~before and after each show or hide of a tab~~ after a tab is displayed and after it is hidden. The tab is passed to the callback. Only if the tab was actually active will it be passed. Before, all videos in all tabs were reset by the stopVideo function which can create more requests than necessary.

~~The old callBack functions are only needed if there are multiple tab-contents for the same tab and something needs to happen right before or after everything.~~

~~I am sorry that the other pull request is included.~~
