### PR TITLE
Fixed bug when tabs are not siblings.

### DIFF
--- a/src/js/tabby.js
+++ b/src/js/tabby.js
@@ -121,24 +121,20 @@
 		// Variables
 		var isLinkList = toggle.parentNode.tagName.toLowerCase() === 'li' ? true : false;
 		var toggleSiblings = isLinkList ? getSiblings(toggle.parentNode) : getSiblings(toggle);
-		var tabSiblings = getSiblings(tab);
 
-		// Hide toggles
 		forEach(toggleSiblings, function (sibling) {
+			// Hide toggles
 			sibling.classList.remove( settings.toggleActiveClass );
 			if ( isLinkList ) {
 				sibling.querySelector('[data-tab]').classList.remove( settings.toggleActiveClass );
 			}
-		});
 
-		// Hide tabs
-		forEach(tabSiblings, function (tab) {
-			if ( tab.classList.contains( settings.contentActiveClass ) ) {
-				stopVideos(tab);
-				tab.classList.remove( settings.contentActiveClass );
-			}
+			// Hide tabs
+                    	var el = isLinkList ? sibling.querySelector('[data-tab]') : sibling;
+                    	var tab = document.querySelector( el.getAttribute('data-tab') );
+                    	stopVideos( tab );
+                    	tab.classList.remove( settings.contentActiveClass );
 		});
-
 	};
 
 	/**


### PR DESCRIPTION
Hello, 

My HTML structure looks like this : 

``` html
<!-- Toggles -->
<ul>
<li>
  <a data-tab="#tab1">Toggle 1</a>
</li>
<li>
  <a data-tab="#tab2">Toggle 2</a>
</li>
</ul>
<!-- Tabs -->
<div class="someClass">
  <div id="tab1">
    Tab content
  </div>
</div>
<div class="someClass">
  <div id="tab2">
    Tab content
  </div>
</div>
```

Tabby is not able to toggle the tabs correctly because it targets the element's siblings. 

I changed the `hideOtherTabs` function to rely on data attributes to target tabs. 
