### PR TITLE
Fixed issue with settings callback not being called

### DIFF
--- a/src/js/tabby.js
+++ b/src/js/tabby.js
@@ -257,15 +257,15 @@
 	tabby.toggleTab = function ( toggle, tabID, options ) {
 
 		// Selectors and variables
-		var settings = extend( settings || defaults, options || {} );  // Merge user options with defaults
+		var toggleSettings = extend( settings || defaults, options || {} );  // Merge user options with defaults
 		var tabs = document.querySelectorAll(tabID); // Get tab content
 
 		// Toggle visibility of the toggles and tabs
-		toggleToggles(toggle, settings);
-		toggleTabs( tabID, settings );
+		toggleToggles(toggle, toggleSettings);
+		toggleTabs( tabID, toggleSettings );
 
 		// Run callbacks after toggling tab
-		settings.callback( toggle, tabID );
+		toggleSettings.callback( toggle, tabID );
 
 	};
 


### PR DESCRIPTION
There was a bug that prevented callback in settings being called, because of a local variable "settings" having the same name (the variable is instantiated in the beginning of the scope). This fixes the bug.