### PR TITLE
fix: preventing removal id

### DIFF
--- a/src/js/tabby.js
+++ b/src/js/tabby.js
@@ -424,7 +424,9 @@
 
 		// If clicked tab is cached, reset it's ID
 		if ( tab ) {
-			tab.id = tab.getAttribute( 'data-tab-id' );
+			if (tab.getAttribute( 'data-tab-id' )) {
+                		tab.id = tab.getAttribute( 'data-tab-id' );
+            		}
 			tab = null;
 		}
 


### PR DESCRIPTION
In some cases, the removal took place id. As a result, the tab could not be opened