### PR TITLE
Fixing iOS web app bug

### DIFF
--- a/src/js/tabby.js
+++ b/src/js/tabby.js
@@ -431,7 +431,11 @@
 		if ( !tab ) return;
 		tab.setAttribute( 'data-tab-id', tab.id );
 		tab.id = '';
-
+		
+		// Without preventDefault() the tab change will open page in Safari if using iPhone web app
+		// To actually change the tab content, we need to still change window.location value
+		event.preventDefault();
+		window.location = event.target.href;
 	};
 
 	/**


### PR DESCRIPTION
When tabby was used in iPhone fullscreen web app, clicking the tab would open the new tab in Safari as a web page instead of keeping it in the web app itself. This is fixed now: tabs work as they used to, but they also work in web app.

Tested on iPhone7, running iOS 10.3.1. Web app was created with Rails 5.0.1.